### PR TITLE
Adds in a fix for single digit zones

### DIFF
--- a/snowex_db/interpretation.py
+++ b/snowex_db/interpretation.py
@@ -165,7 +165,7 @@ def convert_cardinal_to_degree(cardinal):
 
 def manage_utm_zone(info):
     """
-    Maanage the nuance of having a utm zone string sometimes and
+    Manage the nuance of having a utm zone string sometimes and
     then not being in the keys at all. If the utm_zone is in the
     dictionary then convert it to an integer. Otherwise add with
     assign None
@@ -177,7 +177,7 @@ def manage_utm_zone(info):
     """
     if 'utm_zone' in info.keys():
         info['utm_zone'] = int(''.join([c for c in info['utm_zone'] if c.isnumeric()]))
-        info['epsg'] = int(f"269{info['utm_zone']}")
+        info['epsg'] = int(f"269{info['utm_zone']:02}")
     elif 'epsg' in info.keys():
         if info['epsg'] is not None:
             info['utm_zone'] = int(str(info['epsg'])[-2:])

--- a/snowex_db/projection.py
+++ b/snowex_db/projection.py
@@ -61,7 +61,7 @@ def reproject_point_in_dict(info, is_northern=True, zone_number=None):
     # Assuming NAD83, add epsg code
     if 'utm_zone' in result.keys():
         if result['utm_zone'] is not None:
-            result['epsg'] = int(f"269{result['utm_zone']}")
+            result['epsg'] = int(f"269{result['utm_zone']:02}")
     else:
         result['utm_zone'] = None
         result['epsg'] = None

--- a/tests/test_interpretation.py
+++ b/tests/test_interpretation.py
@@ -137,12 +137,17 @@ def test_get_InSar_flight_comment(data_name, expected):
     assert comment == expected
 
 
-@pytest.mark.parametrize("info, expected_zone", [
+@pytest.mark.parametrize("info, key, expected_zone", [
     # Test a string zone is used
-    ({'utm_zone': '12N'}, 12),
+    ({'utm_zone': '12N'}, 'utm_zone', 12),
     # Test utm_zone not provided
-    ({}, None),
+    ({}, 'utm_zone', None),
+    # Test single/double digit zones
+    ({'utm_zone': '6'}, 'epsg', 26906),
+    ({'utm_zone': '11'}, 'epsg', 26911),
+
 ])
-def test_manage_utm_zone(info, expected_zone):
+def test_manage_utm_zone(info, key, expected_zone):
     result = manage_utm_zone(info)
-    assert result['utm_zone'] == expected_zone
+    assert result[key] == expected_zone
+

--- a/tests/test_projection.py
+++ b/tests/test_projection.py
@@ -25,7 +25,7 @@ from snowex_db.projection import *
     # Confirm we force the zone to zone 12
     ({'latitude': 39.097464, 'longitude': -107.862476}, 12,
      {'northing': 4332280.1658, 'easting': 771338.607, "utm_zone": 12}),
-    # Test Missing missing longitude
+    # Test missing longitude
     ({"utm_zone": "10N", "easting": "757215", "northing": "4288778", "latitude": "38.71025", "longitude": ""}, None,
      {"utm_zone": 10, "easting": 757215.0, "northing": 4288778.0, "latitude": 38.71025, "longitude": -120.041884,
       'epsg': 26910}, ),
@@ -34,6 +34,8 @@ from snowex_db.projection import *
      {"utm_zone": 10, "latitude": 38.71025, "longitude": -120.041884, 'epsg': 26910},),
     # Test moving past when nothing is provided
     ({}, None, {"utm_zone": None, 'epsg': None},),
+    # Test single digit zones.
+    ({'easting': 465058.37445, 'northing': 7193480.256156, 'utm_zone': 6}, None, {'epsg':26906})
 ])
 def test_reproject_point_in_dict(info, utm_zone, expected):
     """


### PR DESCRIPTION
Fixes #29 

Single digit zones was interpreted without a 0 preceding it. Added two tests to capture it. While I was in there I cleaned up unused imports and imported test functions explicitly. 
