### PR TITLE
fix: convert to string for cases where Path object is returned 

### DIFF
--- a/scripts/upload/add_alaska_pits_2023.py
+++ b/scripts/upload/add_alaska_pits_2023.py
@@ -47,8 +47,8 @@ def main(file_list: list, doi: str) -> None:
         file
         for file in file_list
         if str(file).lower().endswith(".csv")
-        and not any(name in file for name in ignore_files)
-        and not any(name in file for name in ignore_data)
+        and not any(name in str(file) for name in ignore_files)
+        and not any(name in str(file) for name in ignore_data)
     ]
 
     LOG.info(f"Uploading DOI: {doi} with {len(file_list)} files.")


### PR DESCRIPTION
This is an addendum to #102: in cases where `earthaccess_data.py` returns a list of Path objects, the Alaska script will fail when trying to iterate through a Path object. This is a not-so-elegant fix for now. Ideally we should work with Path object throughout but this can be a future enhancement. 