### PR TITLE
fix: remove leftover git merge conflict notices in script

### DIFF
--- a/scripts/upload/add_smp.py
+++ b/scripts/upload/add_smp.py
@@ -7,13 +7,8 @@ import fileinput
 from earthaccess_data import get_files
 from import_logger import get_logger
 
-<<<<<<< HEAD
 from snowexsql.db import db_session_with_credentials
 from snowex_db.upload.layers import UploadProfileData
-=======
-from snowex_db.utilities import get_logger
-import concurrent.futures
->>>>>>> 1892ebd (removed Batch Uploader classes)
 
 LOG = get_logger()
 


### PR DESCRIPTION
Similar to #101, there was some leftover git merge notices in this script. 