### PR TITLE
enable custom download directory for earthaccess

### DIFF
--- a/scripts/upload/earthaccess_data.py
+++ b/scripts/upload/earthaccess_data.py
@@ -2,10 +2,16 @@ import contextlib
 from typing import Generator, List
 
 import earthaccess
+import os
 from pathlib import Path
 
-DOWNLOAD_FOLDER = Path(__file__).parent.parent / "download" / "data"
-
+# option to set custom download folder via env variable
+DOWNLOAD_FOLDER = Path(
+    os.environ.get(
+        "SNOWEX_DOWNLOAD_FOLDER",
+        Path(__file__).parent.parent / "download" / "data"
+    )
+)
 
 @contextlib.contextmanager
 def get_files(


### PR DESCRIPTION
This creates flexibility in assigning the folder path to hold temporary data downloaded from earthaccess. This is useful for the EC2 db deployment where my larger data directory resides outside of the smaller deployment volume. 