### PR TITLE
fix: delete default db configuration in __init__.py

### DIFF
--- a/snowex_db/__init__.py
+++ b/snowex_db/__init__.py
@@ -3,15 +3,15 @@
 __author__ = """Micah Johnson"""
 __version__ = '0.1.0'
 
-from snowexsql.db import get_db
-from snowexsql.api import DB_NAME
-from contextlib import contextmanager
+# from snowexsql.db import get_db
+# from snowexsql.api import DB_NAME
+# from contextlib import contextmanager
 
 
-@contextmanager
-def db_session(db_name, credentials):
-    # use default_name
-    db_name = db_name or DB_NAME
-    engine, session = get_db(db_name, credentials=credentials)
-    yield session, engine
-    session.close()
+# @contextmanager
+# def db_session(db_name, credentials):
+#     # use default_name
+#     db_name = db_name or DB_NAME
+#     engine, session = get_db(db_name, credentials=credentials)
+#     yield session, engine
+#     session.close()

--- a/snowex_db/__init__.py
+++ b/snowex_db/__init__.py
@@ -2,16 +2,3 @@
 
 __author__ = """Micah Johnson"""
 __version__ = '0.1.0'
-
-# from snowexsql.db import get_db
-# from snowexsql.api import DB_NAME
-# from contextlib import contextmanager
-
-
-# @contextmanager
-# def db_session(db_name, credentials):
-#     # use default_name
-#     db_name = db_name or DB_NAME
-#     engine, session = get_db(db_name, credentials=credentials)
-#     yield session, engine
-#     session.close()

--- a/snowex_db/__init__.py
+++ b/snowex_db/__init__.py
@@ -1,4 +1,0 @@
-"""Top-level package for snowex_db."""
-
-__author__ = """Micah Johnson"""
-__version__ = '0.1.0'


### PR DESCRIPTION
Setting a default db configuration in this file is no longer needed, due to https://github.com/SnowEx/snowexsql/pull/204. I will be updating snowexsql api.py file accordingly, soon.